### PR TITLE
refactor: pikepdf依存関係を削除しpypdfのみを使用

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,6 @@ requires-python = ">=3.12"
 dependencies = [
     "click>=8.2.1",
     "pypdf>=4.0.0",
-    "pikepdf>=8.0.0",
 ]
 
 [project.scripts]

--- a/src/pdf_chapter_splitter/splitter.py
+++ b/src/pdf_chapter_splitter/splitter.py
@@ -2,7 +2,6 @@ import re
 from pathlib import Path
 from typing import List, Tuple, Optional
 from pypdf import PdfReader, PdfWriter
-import pikepdf
 
 
 class PDFChapterSplitter:
@@ -13,39 +12,25 @@ class PDFChapterSplitter:
         
     def extract_text(self) -> str:
         """PDFからテキストを抽出"""
-        # まずpikepdfで試行（より堅牢）
+        print("pypdf でPDFを読み込み中...")
         try:
-            print("pikepdf でPDFを読み込み中...")
-            with pikepdf.Pdf.open(self.pdf_path) as pdf:
-                print(f"PDFページ数: {len(pdf.pages)}")
-                
-                # pikepdf用のテキスト抽出は限定的なのでpypdfにフォールバック
-                raise Exception("pikepdfからpypdfにフォールバック")
-                
-        except Exception as pike_error:
-            print(f"pikepdf での読み込み失敗: {pike_error}")
-            print("pypdf での読み込みを試行中...")
-            
-            # pypdfで試行
-            try:
-                with open(self.pdf_path, 'rb') as file:
-                    reader = PdfReader(file, strict=False)
-                    print(f"pypdf でPDFページ数: {len(reader.pages)}")
-                    text = ""
-                    for i, page in enumerate(reader.pages):
-                        try:
-                            page_text = page.extract_text()
-                            text += page_text + "\n"
-                            if i == 0:  # 最初のページの一部を表示
-                                print(f"最初のページのサンプル: {page_text[:200]}...")
-                        except Exception as e:
-                            print(f"警告: ページ {i+1} の読み込みでエラー: {e}")
-                            continue
-                return text
-                
-            except Exception as e:
-                print(f"pypdf でもエラー: {e}")
-                raise
+            with open(self.pdf_path, 'rb') as file:
+                reader = PdfReader(file, strict=False)
+                print(f"PDFページ数: {len(reader.pages)}")
+                text = ""
+                for i, page in enumerate(reader.pages):
+                    try:
+                        page_text = page.extract_text()
+                        text += page_text + "\n"
+                        if i == 0:  # 最初のページの一部を表示
+                            print(f"最初のページのサンプル: {page_text[:200]}...")
+                    except Exception as e:
+                        print(f"警告: ページ {i+1} の読み込みでエラー: {e}")
+                        continue
+            return text
+        except Exception as e:
+            print(f"pypdf でエラー: {e}")
+            raise
     
     def find_chapter_boundaries(self, text: str) -> List[Tuple[int, str]]:
         """章の境界を見つける（シンプルアプローチ：各章の最初の出現のみ採用）"""


### PR DESCRIPTION
## Summary
- pikepdfはほとんどのケースでpypdfにフォールバックしていたため削除
- extract_text()メソッドを簡素化してpypdfのみを使用し、コードの複雑性を削減

## Test plan
- [x] 基本的なインポートが動作することを確認
- [x] 既存のテストケースを実行（一部のテストは章検出ロジックのテストなので、pikepdf削除とは無関係な問題）

🤖 Generated with [Claude Code](https://claude.ai/code)